### PR TITLE
MODE-1479 Exception Adding/Editing Property Definition's Value Constraint In CND Editor

### DIFF
--- a/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/PropertyDialog.java
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/PropertyDialog.java
@@ -57,6 +57,7 @@ import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.jboss.tools.modeshape.jcr.ItemOwnerProvider;
 import org.jboss.tools.modeshape.jcr.Messages;
+import org.jboss.tools.modeshape.jcr.MultiValidationStatus;
 import org.jboss.tools.modeshape.jcr.PropertyDefinition;
 import org.jboss.tools.modeshape.jcr.PropertyDefinition.PropertyName;
 import org.jboss.tools.modeshape.jcr.QualifiedName;
@@ -1134,8 +1135,12 @@ final class PropertyDialog extends FormDialog {
 
                         // check for duplicate
                         currentDefaultValues.add(newValue);
-                        return CndValidator.validateDefaultValues(propDefn.getName(), propDefn.getType(), currentDefaultValues,
-                                                                  accessExistingNamespacePrefixes());
+                        MultiValidationStatus validationStatus = CndValidator.validateDefaultValues(propDefn.getName(),
+                                                                                                    propDefn.getType(),
+                                                                                                    currentDefaultValues,
+                                                                                                    accessExistingNamespacePrefixes());
+                        currentDefaultValues.remove(newValue);
+                        return validationStatus;
                     }
                 };
 
@@ -1158,7 +1163,7 @@ final class PropertyDialog extends FormDialog {
 
     void handleAddValueConstraint() {
         final PropertyDefinition propDefn = getPropertyDefinition();
-        final Collection<String> currentConstraints = Arrays.asList(propDefn.getValueConstraints());
+        final Collection<String> currentConstraints = new ArrayList<String>(Arrays.asList(propDefn.getValueConstraints()));
         final StringValueEditorDialog dialog = new StringValueEditorDialog(getShell()) {
 
             /**
@@ -1191,7 +1196,10 @@ final class PropertyDialog extends FormDialog {
 
                         // check for duplicate
                         currentConstraints.add(newValue);
-                        return CndValidator.validateValueConstraints(propDefn.getName(), currentConstraints);
+                        MultiValidationStatus validationStatus = CndValidator.validateValueConstraints(propDefn.getName(),
+                                                                                                       currentConstraints);
+                        currentConstraints.remove(newValue);
+                        return validationStatus;
                     }
                 };
 
@@ -1301,8 +1309,12 @@ final class PropertyDialog extends FormDialog {
 
                         // check for duplicate
                         currentDefaultValues.add(newValue);
-                        return CndValidator.validateDefaultValues(propDefn.getName(), propDefn.getType(), currentDefaultValues,
-                                                                  accessExistingNamespacePrefixes());
+                        MultiValidationStatus validationStatus = CndValidator.validateDefaultValues(propDefn.getName(),
+                                                                                                    propDefn.getType(),
+                                                                                                    currentDefaultValues,
+                                                                                                    accessExistingNamespacePrefixes());
+                        currentDefaultValues.remove(newValue);
+                        return validationStatus;
                     }
                 };
 
@@ -1378,7 +1390,10 @@ final class PropertyDialog extends FormDialog {
 
                         // check for duplicate
                         currentConstraints.add(newValue);
-                        return CndValidator.validateValueConstraints(propDefn.getName(), currentConstraints);
+                        MultiValidationStatus validationStatus = CndValidator.validateValueConstraints(propDefn.getName(),
+                                                                                                       currentConstraints);
+                        currentConstraints.remove(newValue);
+                        return validationStatus;
                     }
                 };
 

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/Messages.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/Messages.java
@@ -163,6 +163,11 @@ public final class Messages extends NLS {
     public static String emptyValue;
 
     /**
+     * A message indicating a property definition's value constraint is empty.
+     */
+    public static String emptyValueConstraint;
+
+    /**
      * A message indicating a property definition is missing value constraints. One parameter, the property definition name, is
      * required.
      */

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CndValidator.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CndValidator.java
@@ -1629,7 +1629,11 @@ public final class CndValidator {
      * @return the status (never <code>null</code>)
      */
     public static ValidationStatus validateValueConstraint( final String constraint ) {
-        Utils.verifyIsNotEmpty(constraint, "constraint"); //$NON-NLS-1$
+        try {
+            Utils.verifyIsNotEmpty(constraint, "constraint"); //$NON-NLS-1$
+        } catch (IllegalArgumentException e) {
+            return ValidationStatus.createErrorMessage(StatusCodes.EMPTY_VALUE_CONSTRAINT, Messages.emptyValueConstraint);
+        }
 
         // TODO implement validateValueConstraint to make sure constraint is property syntax
         return ValidationStatus.OK_STATUS;
@@ -1789,6 +1793,7 @@ public final class CndValidator {
         int EMPTY_VALUE_CONSTRAINTS = 285;
         int DUPLICATE_VALUE_CONSTRAINT = 290;
         int VALUE_CONSTRAINTS_EXIST_BUT_MARKED_AS_VARIANT = 295;
+        int EMPTY_VALUE_CONSTRAINT = 300;
     }
 
 }

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/messages.properties
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/messages.properties
@@ -57,6 +57,7 @@ emptySuperTypes = The node type definition "{0}" must have at least one super ty
 emptyUnqualifiedName = The {0} has an empty unqualified name.
 # 0 = property or attribute name of a node type definition, property definition, or child node definition
 emptyValue = A "{0}" value cannot be empty
+emptyValueConstraint = The value constraint cannot be empty.
 # 0 = property definition name
 emptyValueConstraints = The property definition "{0}" must have at least one value constraint.
 # 0 = property value, 1 = property type, 2 = property name

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CndValidatorTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CndValidatorTest.java
@@ -205,6 +205,16 @@ public class CndValidatorTest {
     }
 
     @Test
+    public void emptyValueConstraintShouldBeAnError() {
+        // setup
+        final ValidationStatus status = CndValidator.validateValueConstraint(Utils.EMPTY_STRING);
+
+        // tests
+        assertTrue(status.isError());
+        assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.EMPTY_VALUE_CONSTRAINT)); //$NON-NLS-1$
+    }
+
+    @Test
     public void invalidQualifiedNameQualifierShouldBeAnError() {
         // setup
         final QualifiedName qname = new QualifiedName(Constants.QUALIFIER1 + "Changed", Constants.UNQUALIFIED_NAME1); //$NON-NLS-1$
@@ -407,6 +417,16 @@ public class CndValidatorTest {
         // tests
         assertTrue(status.isError());
         assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.EMPTY_QUERY_OPERATOR)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void nullValueConstraintShouldBeAnError() {
+        // setup
+        final ValidationStatus status = CndValidator.validateValueConstraint(null);
+
+        // tests
+        assertTrue(status.isError());
+        assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.EMPTY_VALUE_CONSTRAINT)); //$NON-NLS-1$
     }
 
     @Test


### PR DESCRIPTION
The exception was caused by trying to add to unmodifiable list. Also found that the same issue occurred when adding/editing a property definition's default values so that was fixed as well.
