### PR TITLE
MODE-1539 CND Preference Page Is Uncategorized When Installing Just The CND Feature

### DIFF
--- a/plugins/org.jboss.tools.modeshape.jcr.ui/plugin.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/plugin.xml
@@ -29,7 +29,7 @@
          point="org.eclipse.ui.preferencePages">
       <page
             name="%cndPreferencePage.name"
-            category="modeShapePreferencePage"
+            category="org.jboss.tools.modeshape.ui.rootModeShapeToolsPreferencePage"
             class="org.jboss.tools.modeshape.jcr.ui.preferences.CndPreferencePage"
             id="org.jboss.tools.modeshape.jcr.ui.jcrPreferencePage">
       </page>

--- a/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Activator: org.jboss.tools.modeshape.rest.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime;bundle-version="3.7.0",
+ org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.ui.console,
  org.eclipse.jface.text,

--- a/plugins/org.jboss.tools.modeshape.rest/plugin.properties
+++ b/plugins/org.jboss.tools.modeshape.rest/plugin.properties
@@ -18,6 +18,7 @@ ignoredResourcesPreferencePage = Ignored Resources
 modeShapeCategory = ModeShape
 preferenceInitializer = Preference Initializer for default values
 publishCommand.name = Publish
+publishingPreferencePage.name = Publishing
 serverView = ModeShape
 showPublishedLocationsCommand.name = Show Published Locations
 unpublishCommand.name = Unpublish

--- a/plugins/org.jboss.tools.modeshape.rest/plugin.xml
+++ b/plugins/org.jboss.tools.modeshape.rest/plugin.xml
@@ -206,9 +206,10 @@
    <extension
          point="org.eclipse.ui.preferencePages">
       <page
-            name="%modeShapeCategory"
+            name="%publishingPreferencePage.name"
+            category="org.jboss.tools.modeshape.ui.rootModeShapeToolsPreferencePage"
             class="org.jboss.tools.modeshape.rest.preferences.ModeShapePreferencePage"
-            id="modeShapePreferencePage">
+            id="org.jboss.tools.modeshape.rest.publishingPreferencePage">
       </page>
    </extension>
 
@@ -217,9 +218,9 @@
          point="org.eclipse.ui.preferencePages">
       <page
             name="%ignoredResourcesPreferencePage"
-            category="modeShapePreferencePage"
+            category="org.jboss.tools.modeshape.rest.publishingPreferencePage"
             class="org.jboss.tools.modeshape.rest.preferences.IgnoredResourcesPreferencePage"
-            id="modeShapeIgnoredResourcesPreferencePage">
+            id="org.jboss.tools.modeshape.rest.modeShapeIgnoredResourcesPreferencePage">
       </page>
 
 <!-- Preference Initializer -->

--- a/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/IUiConstants.java
+++ b/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/IUiConstants.java
@@ -133,12 +133,12 @@ public interface IUiConstants {
         /**
          * The ignored resources preference page ID.
          */
-        String IGNORED_RESOURCES_PREFERENCE_PAGE_ID = "modeShapeIgnoredResourcesPreferencePage"; //$NON-NLS-1$
+        String IGNORED_RESOURCES_PREFERENCE_PAGE_ID = "org.jboss.tools.modeshape.rest.modeShapeIgnoredResourcesPreferencePage"; //$NON-NLS-1$
 
         /**
          * The main ModeShape preference page ID.
          */
-        String MAIN_PREFERENCE_PAGE_ID = "modeShapePreferencePage"; //$NON-NLS-1$
+        String PUBLISHING_PREFERENCE_PAGE_ID = "org.jboss.tools.modeshape.rest.publishingPreferencePage"; //$NON-NLS-1$
 
     }
 

--- a/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/wizards/PublishPage.java
+++ b/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/wizards/PublishPage.java
@@ -14,7 +14,7 @@ package org.jboss.tools.modeshape.rest.wizards;
 import static org.jboss.tools.modeshape.rest.IUiConstants.HelpContexts.PUBLISH_DIALOG_HELP_CONTEXT;
 import static org.jboss.tools.modeshape.rest.IUiConstants.Preferences.ENABLE_RESOURCE_VERSIONING;
 import static org.jboss.tools.modeshape.rest.IUiConstants.Preferences.IGNORED_RESOURCES_PREFERENCE;
-import static org.jboss.tools.modeshape.rest.IUiConstants.Preferences.MAIN_PREFERENCE_PAGE_ID;
+import static org.jboss.tools.modeshape.rest.IUiConstants.Preferences.PUBLISHING_PREFERENCE_PAGE_ID;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -721,7 +721,7 @@ public final class PublishPage extends WizardPage implements IServerRegistryList
     void handleOpenPreferencePage() {
         // open preference page and only allow the pref page where the version
         // setting is
-        PreferencesUtil.createPreferenceDialogOn(getShell(), MAIN_PREFERENCE_PAGE_ID, new String[] { MAIN_PREFERENCE_PAGE_ID },
+        PreferencesUtil.createPreferenceDialogOn(getShell(), PUBLISHING_PREFERENCE_PAGE_ID, new String[] { PUBLISHING_PREFERENCE_PAGE_ID },
                                                  null).open();
     }
 

--- a/plugins/org.jboss.tools.modeshape.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.jboss.tools.modeshape.ui/OSGI-INF/l10n/bundle.properties
@@ -11,3 +11,5 @@
 #
 bundleName = ModeShape Tools Eclipse UI Plug-in
 bundleVendor = JBoss by Red Hat
+
+rootPreferencePage.name = Content Repository

--- a/plugins/org.jboss.tools.modeshape.ui/build.properties
+++ b/plugins/org.jboss.tools.modeshape.ui/build.properties
@@ -15,4 +15,3 @@ bin.includes = META-INF/,\
                OSGI-INF/
 jars.compile.order = .
 source.. = src/
-               

--- a/plugins/org.jboss.tools.modeshape.ui/plugin.xml
+++ b/plugins/org.jboss.tools.modeshape.ui/plugin.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<!-- 
+  - See the COPYRIGHT.txt file distributed with this work for information
+  - regarding copyright ownership.
+  -
+  - This software is made available by Red Hat, Inc. under the terms of the
+  - Eclipse Public License v1.0 which accompanies this distribution and is
+  - available at http://www.eclipse.org/legal/epl-v10.html.
+  -
+  - See the AUTHORS.txt file in the distribution for a full listing of
+  - individual contributors.
+-->
+<plugin>
+
+<!-- Root Preference Page -->
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            class="org.jboss.tools.modeshape.ui.preferences.RootPreferencePage"
+            id="org.jboss.tools.modeshape.ui.rootModeShapeToolsPreferencePage"
+            name="%rootPreferencePage.name">
+      </page>
+   </extension>
+
+</plugin>

--- a/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/UiMessages.java
+++ b/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/UiMessages.java
@@ -60,6 +60,11 @@ public class UiMessages extends NLS {
     public static String questionDialogTitle;
 
     /**
+     * The message displayed at the top of the root preference page.
+     */
+    public static String rootPrefPageMsg;
+
+    /**
      * A message indicating a <code>null</code> or empty string was found. One parameter, a name identifying the string, is
      * required.
      */

--- a/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/preferences/RootPreferencePage.java
+++ b/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/preferences/RootPreferencePage.java
@@ -1,0 +1,86 @@
+/*
+ * ModeShape (http://www.modeshape.org)
+ * See the COPYRIGHT.txt file distributed with this work for information
+ * regarding copyright ownership.  Some portions may be licensed
+ * to Red Hat, Inc. under one or more contributor license agreements.
+ * See the AUTHORS.txt file in the distribution for a full listing of
+ * individual contributors.
+ *
+ * ModeShape is free software. Unless otherwise indicated, all code in ModeShape
+ * is licensed to you under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * ModeShape is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.tools.modeshape.ui.preferences;
+
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.jboss.tools.modeshape.ui.UiMessages;
+
+/**
+ * An empty preference page that is the root preference page for ModeShape Tools.
+ */
+public class RootPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.jface.preference.PreferencePage#createContents(org.eclipse.swt.widgets.Composite)
+     */
+    @Override
+    protected Control createContents( Composite parent ) {
+        noDefaultAndApplyButton();
+
+        final ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
+        sc.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+        final Composite composite = new Composite(sc, SWT.NULL);
+        composite.setLayout(new GridLayout());
+        composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        sc.setContent(composite);
+
+        final Text text = new Text(composite, SWT.READ_ONLY);
+        text.setBackground(composite.getBackground());
+        text.setText(UiMessages.rootPrefPageMsg);
+
+        applyDialogFont(composite);
+        final Point minSize = composite.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+        composite.setSize(minSize);
+
+        // set scrollbar composite's min size so page is expandable but has scrollbars when needed
+        sc.setMinSize(minSize);
+        sc.setExpandHorizontal(true);
+        sc.setExpandVertical(true);
+
+        return composite;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.eclipse.ui.IWorkbenchPreferencePage#init(org.eclipse.ui.IWorkbench)
+     */
+    @Override
+    public void init( IWorkbench workbench ) {
+        // nothing to do
+    }
+}

--- a/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/uiMessages.properties
+++ b/plugins/org.jboss.tools.modeshape.ui/src/org/jboss/tools/modeshape/ui/uiMessages.properties
@@ -13,5 +13,6 @@ infoDialogTitle = Info
 messageColumnHeader = Message
 objectIsNull = Object {0} is null
 questionDialogTitle = Question
+rootPrefPageMsg = Expand the tree to edit preferences for a specific feature. 
 stringIsEmpty = String {0} is empty
 warningDialogTitle = Warning


### PR DESCRIPTION
Created a root preference page that informs user to open preference tree to see other preferences. The CND editor preferences and the publishing preferences are child pages to the root preference page. The publishing ignored resources page remains a child page to the main publishing page. Features can now be installed individually or together and there preference page locations remain the same.
