### PR TITLE
MODE-1567 ModeShape Tools Feature Names Should Not Reference JBoss Tools

### DIFF
--- a/features/org.jboss.tools.modeshape.jcr.feature/feature.properties
+++ b/features/org.jboss.tools.modeshape.jcr.feature/feature.properties
@@ -10,7 +10,7 @@
 # individual contributors.
 #
 
-featureName = ModeShape Tools JCR CND Editor for Eclipse
+featureName = JCR Compact Node Definition (CND) Editor
 featureProvider = JBoss by Red Hat
 
 description = Provides a JCR CND editor.

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/feature.properties
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/feature.properties
@@ -10,7 +10,7 @@
 # individual contributors.
 #
 
-featureName = JBoss Tools - Tests - ModeShape JCR
+featureName = JCR Compact Node Definition (CND) Editor Tests
 featureProvider = JBoss by Red Hat
 
 descriptionUrl=http://www.jboss.org/tools

--- a/features/org.jboss.tools.modeshape.rest.feature/feature.properties
+++ b/features/org.jboss.tools.modeshape.rest.feature/feature.properties
@@ -10,7 +10,7 @@
 # individual contributors.
 #
 
-featureName = ModeShape JCR REST Tools for Eclipse
+featureName = ModeShape Client
 featureProvider = JBoss by Red Hat
 
 description = Provides a resource publishing and unpublishing capability to ModeShape repositories.

--- a/features/org.jboss.tools.modeshape.rest.test.feature/feature.properties
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/feature.properties
@@ -10,7 +10,7 @@
 # individual contributors.
 #
 
-featureName = JBoss Tools - Tests - ModeShape
+featureName = ModeShape Client Tests
 featureProvider = JBoss by Red Hat
 
 descriptionUrl=http://www.jboss.org/tools

--- a/site/category.xml
+++ b/site/category.xml
@@ -4,32 +4,32 @@
       To install these features, point Eclipse at this site.
    </description>
    <feature url="features/org.jboss.tools.modeshape.jcr.feature_0.0.0.jar" id="org.jboss.tools.modeshape.jcr.feature" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.jcr.test.feature_0.0.0.jar" id="org.jboss.tools.modeshape.jcr.test.feature" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.rest.feature_0.0.0.jar" id="org.jboss.tools.modeshape.rest.feature" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.rest.test.feature_0.0.0.jar" id="org.jboss.tools.modeshape.rest.test.feature" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.jcr.feature.source_0.0.0.jar" id="org.jboss.tools.modeshape.jcr.feature.source" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.jcr.test.feature.source_0.0.0.jar" id="org.jboss.tools.modeshape.jcr.test.feature.source" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.rest.feature.source_0.0.0.jar" id="org.jboss.tools.modeshape.rest.feature.source" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
    <feature url="features/org.jboss.tools.modeshape.rest.test.feature.source_0.0.0.jar" id="org.jboss.tools.modeshape.rest.test.feature.source" version="0.0.0">
-      <category name="JBoss Tools modeshape Nightly Build Update Site"/>
+      <category name="ModeShape Tools"/>
    </feature>
-   <category-def name="JBoss Tools modeshape Nightly Build Update Site" label="JBoss Tools modeshape Nightly Build Update Site">
+   <category-def name="ModeShape Tools" label="ModeShape Tools">
       <description>
-         JBoss Tools modeshape Nightly Build Update Site: contains all features in this build.
+         ModeShape Tools Update Site: contains all features.
       </description>
    </category-def>
 </site>


### PR DESCRIPTION
Removed references to JBT and renamed features and feature category.
