### PR TITLE
MODE-1569 ModeShape Tools Update-Site Missing ModeShape Client Plugin

### DIFF
--- a/features/org.jboss.tools.modeshape.rest.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/feature.xml
@@ -20,6 +20,12 @@
    </license>
 
    <plugin
+         id="org.jboss.tools.modeshape.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+   <plugin
          id="org.jboss.tools.modeshape.rest"
          download-size="0"
          install-size="0"

--- a/plugins/org.jboss.tools.modeshape.ui/build.properties
+++ b/plugins/org.jboss.tools.modeshape.ui/build.properties
@@ -12,6 +12,7 @@
 bin.includes = META-INF/,\
                .,\
                icons/,\
-               OSGI-INF/
+               OSGI-INF/,\
+               plugin.xml
 jars.compile.order = .
 source.. = src/


### PR DESCRIPTION
Needed to add plugin.xml from tools.modeshape.ui to build.properties. This adds the root preference page. Needed to explicitly add tools.modeshape.ui to features to make sure it gets into update-site.
