### PR TITLE
MODE-1644 Valid Default Values For Name Property Types Are Displaying An Error

### DIFF
--- a/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/CndFormsEditorPage.java
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/CndFormsEditorPage.java
@@ -2516,6 +2516,7 @@ class CndFormsEditorPage extends CndEditorPage implements PropertyChangeListener
                                                                    Messages.nodeTypeDefinitionName,
                                                                    getCnd().getNamespacePrefixes());
         dialog.setExistingQNames(getNodeTypeNames());
+        dialog.setProposalProvider(QualifiedNameProposalProvider.NO_PROPOSALS_PROVIDER);
         dialog.create();
         dialog.getShell().pack();
 

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/PropertyDialog.java
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/PropertyDialog.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
@@ -112,7 +111,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * Used to create a new property definition.
-     * 
+     *
      * @param parentShell the parent shell (can be <code>null</code>)
      * @param ownerProvider an item owner provider for the new property (cannot be <code>null</code>)
      * @param existingPropertyNames the existing property names (can be <code>null</code> or empty)
@@ -125,10 +124,10 @@ final class PropertyDialog extends FormDialog {
                            final Collection<String> existingNamespacePrefixes,
                            final boolean nodeTypeQueryable ) {
         super(parentShell);
-        this.existingPropertyNames = ((existingPropertyNames == null) ? Collections.<QualifiedName> emptyList()
-                                                                     : new ArrayList<QualifiedName>(existingPropertyNames));
-        this.existingNamespacePrefixes = ((existingNamespacePrefixes == null) ? Collections.<String> emptyList()
-                                                                             : new ArrayList<String>(existingNamespacePrefixes));
+        this.existingPropertyNames = ((existingPropertyNames == null) ? Collections.<QualifiedName>emptyList()
+                                                                      : new ArrayList<QualifiedName>(existingPropertyNames));
+        this.existingNamespacePrefixes = ((existingNamespacePrefixes == null) ? Collections.<String>emptyList()
+                                                                              : new ArrayList<String>(existingNamespacePrefixes));
         this.nodeTypeQueryable = nodeTypeQueryable;
         this.defaultValuesError = new ErrorMessage();
         this.nameError = new ErrorMessage();
@@ -138,7 +137,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * Used to edit a property definition.
-     * 
+     *
      * @param parentShell the parent shell (can be <code>null</code>)
      * @param ownerProvider an item owner provider for the new property (cannot be <code>null</code>)
      * @param existingPropertyNames the existing property names (can be <code>null</code> or empty)
@@ -176,7 +175,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.eclipse.jface.window.Window#configureShell(org.eclipse.swt.widgets.Shell)
      */
     @Override
@@ -187,7 +186,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.eclipse.jface.dialogs.Dialog#createButton(org.eclipse.swt.widgets.Composite, int, java.lang.String, boolean)
      */
     @Override
@@ -211,7 +210,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -226,7 +225,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -242,7 +241,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -262,7 +261,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IContentProvider#dispose()
              */
             @Override
@@ -272,7 +271,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements(java.lang.Object)
              */
             @Override
@@ -283,7 +282,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IContentProvider#inputChanged(org.eclipse.jface.viewers.Viewer, java.lang.Object,
              *      java.lang.Object)
              */
@@ -299,7 +298,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IDoubleClickListener#doubleClick(org.eclipse.jface.viewers.DoubleClickEvent)
              */
             @Override
@@ -312,7 +311,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(org.eclipse.jface.viewers.SelectionChangedEvent)
              */
             @Override
@@ -324,7 +323,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.eclipse.ui.forms.FormDialog#createFormContent(org.eclipse.ui.forms.IManagedForm)
      */
     @Override
@@ -348,10 +347,7 @@ final class PropertyDialog extends FormDialog {
             toolkit.paintBordersFor(topContainer);
 
             { // name
-                this.nameEditor = new QualifiedNameEditor(topContainer,
-                                                          SWT.NONE,
-                                                          toolkit,
-                                                          Messages.propertyDefinitionName,
+                this.nameEditor = new QualifiedNameEditor(topContainer, SWT.NONE, toolkit, Messages.propertyDefinitionName,
                                                           this.existingNamespacePrefixes,
                                                           this.propertyBeingEdited.getQualifiedName());
                 ((GridData)this.nameEditor.getLayoutData()).horizontalSpan = 2;
@@ -360,7 +356,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
                      */
                     @Override
@@ -409,7 +405,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -432,7 +428,9 @@ final class PropertyDialog extends FormDialog {
             toolkit.paintBordersFor(attributesContainer);
 
             { // autocreated
-                final Button btnAutocreated = toolkit.createButton(attributesContainer, CndMessages.autocreatedAttribute, SWT.CHECK);
+                final Button btnAutocreated = toolkit.createButton(attributesContainer,
+                                                                   CndMessages.autocreatedAttribute,
+                                                                   SWT.CHECK);
                 btnAutocreated.setBackground(attributesContainer.getBackground());
 
                 if (isEditMode() && this.propertyBeingEdited.isAutoCreated()) {
@@ -443,7 +441,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -466,7 +464,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -489,7 +487,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -512,7 +510,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -535,7 +533,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -547,7 +545,8 @@ final class PropertyDialog extends FormDialog {
             }
 
             { // noQueryOrder
-                final Button btnNoQueryOrder = toolkit.createButton(attributesContainer, CndMessages.noQueryOrderAttribute,
+                final Button btnNoQueryOrder = toolkit.createButton(attributesContainer,
+                                                                    CndMessages.noQueryOrderAttribute,
                                                                     SWT.CHECK);
                 btnNoQueryOrder.setBackground(attributesContainer.getBackground());
 
@@ -559,7 +558,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -597,8 +596,7 @@ final class PropertyDialog extends FormDialog {
 
                 // select the current qualifier
                 if (isEditMode()) {
-                    final String currentOpv = OnParentVersion.findUsingJcrValue(this.propertyBeingEdited.getOnParentVersion())
-                                                             .toString();
+                    final String currentOpv = OnParentVersion.findUsingJcrValue(this.propertyBeingEdited.getOnParentVersion()).toString();
                     final int index = cbxOpvs.indexOf(currentOpv);
 
                     if (index != -1) {
@@ -610,7 +608,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                      */
                     @Override
@@ -633,7 +631,9 @@ final class PropertyDialog extends FormDialog {
                     toolkit.createLabel(queryOpsContainer, CndMessages.queryOperatorsLabel);
 
                     { // equals query operator
-                        final Button btnEquals = toolkit.createButton(queryOpsContainer, QueryOperator.EQUALS.toString(), SWT.CHECK);
+                        final Button btnEquals = toolkit.createButton(queryOpsContainer,
+                                                                      QueryOperator.EQUALS.toString(),
+                                                                      SWT.CHECK);
                         btnEquals.setBackground(attributesContainer.getBackground());
 
                         if (supportedQueryOps.contains(btnEquals.getText())) {
@@ -644,7 +644,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -657,7 +657,8 @@ final class PropertyDialog extends FormDialog {
                     }
 
                     { // not equals query operator
-                        final Button btnNotEquals = toolkit.createButton(queryOpsContainer, QueryOperator.NOT_EQUALS.toString(),
+                        final Button btnNotEquals = toolkit.createButton(queryOpsContainer,
+                                                                         QueryOperator.NOT_EQUALS.toString(),
                                                                          SWT.CHECK);
                         btnNotEquals.setBackground(attributesContainer.getBackground());
 
@@ -669,7 +670,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -683,7 +684,8 @@ final class PropertyDialog extends FormDialog {
 
                     { // greater than query operator
                         final Button btnGreaterThan = toolkit.createButton(queryOpsContainer,
-                                                                           QueryOperator.GREATER_THAN.toString(), SWT.CHECK);
+                                                                           QueryOperator.GREATER_THAN.toString(),
+                                                                           SWT.CHECK);
                         btnGreaterThan.setBackground(attributesContainer.getBackground());
 
                         if (supportedQueryOps.contains(btnGreaterThan.getText())) {
@@ -694,7 +696,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -707,7 +709,8 @@ final class PropertyDialog extends FormDialog {
                     }
 
                     { // less than query operator
-                        final Button btnLessThan = toolkit.createButton(queryOpsContainer, QueryOperator.LESS_THAN.toString(),
+                        final Button btnLessThan = toolkit.createButton(queryOpsContainer,
+                                                                        QueryOperator.LESS_THAN.toString(),
                                                                         SWT.CHECK);
                         btnLessThan.setBackground(attributesContainer.getBackground());
 
@@ -719,7 +722,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -745,7 +748,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -759,7 +762,8 @@ final class PropertyDialog extends FormDialog {
 
                     { // less than or equals query operator
                         final Button btnLessThanEquals = toolkit.createButton(queryOpsContainer,
-                                                                              QueryOperator.LESS_THAN_EQUALS.toString(), SWT.CHECK);
+                                                                              QueryOperator.LESS_THAN_EQUALS.toString(),
+                                                                              SWT.CHECK);
                         btnLessThanEquals.setBackground(attributesContainer.getBackground());
 
                         if (supportedQueryOps.contains(btnLessThanEquals.getText())) {
@@ -770,7 +774,7 @@ final class PropertyDialog extends FormDialog {
 
                             /**
                              * {@inheritDoc}
-                             * 
+                             *
                              * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
                              */
                             @Override
@@ -896,7 +900,7 @@ final class PropertyDialog extends FormDialog {
                 lblComment.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false));
 
                 Text txtComment = toolkit.createText(commentsContainer, null, Styles.TEXT_STYLE | SWT.MULTI | SWT.H_SCROLL
-                        | SWT.V_SCROLL);
+                                                                              | SWT.V_SCROLL);
                 txtComment.setToolTipText(CndMessages.commentedToolTip);
 
                 final GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
@@ -913,7 +917,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.eclipse.swt.events.ModifyListener#modifyText(org.eclipse.swt.events.ModifyEvent)
                      */
                     @Override
@@ -929,7 +933,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see java.beans.PropertyChangeListener#propertyChange(java.beans.PropertyChangeEvent)
              */
             @Override
@@ -951,7 +955,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -966,7 +970,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -982,7 +986,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.action.Action#run()
              */
             @Override
@@ -1002,7 +1006,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IContentProvider#dispose()
              */
             @Override
@@ -1012,7 +1016,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements(java.lang.Object)
              */
             @Override
@@ -1029,7 +1033,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IContentProvider#inputChanged(org.eclipse.jface.viewers.Viewer, java.lang.Object,
              *      java.lang.Object)
              */
@@ -1045,7 +1049,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.IDoubleClickListener#doubleClick(org.eclipse.jface.viewers.DoubleClickEvent)
              */
             @Override
@@ -1058,7 +1062,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.eclipse.jface.viewers.ISelectionChangedListener#selectionChanged(org.eclipse.jface.viewers.SelectionChangedEvent)
              */
             @Override
@@ -1070,7 +1074,7 @@ final class PropertyDialog extends FormDialog {
 
     /**
      * <strong>Should only be called after the dialog's <code>OK</code> button has been selected.</strong>
-     * 
+     *
      * @return the property definition represented by the dialog UI controls (never <code>null</code>)
      */
     public PropertyDefinition getPropertyDefinition() {
@@ -1107,7 +1111,7 @@ final class PropertyDialog extends FormDialog {
         final StringValueEditorDialog dialog = new StringValueEditorDialog(getShell()) {
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog#getSettings()
              */
             @Override
@@ -1122,12 +1126,15 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog.Validator#validate(java.lang.String)
                      */
                     @Override
                     public ValidationStatus validate( final String newValue ) {
-                        final ValidationStatus status = CndValidator.isValid(newValue, propDefn.getType(), propDefn.getName());
+                        final ValidationStatus status = CndValidator.isValid(newValue,
+                                                                             propDefn.getType(),
+                                                                             propDefn.getName(),
+                                                                             accessExistingNamespacePrefixes());
 
                         if (status.isError()) {
                             return status;
@@ -1155,7 +1162,9 @@ final class PropertyDialog extends FormDialog {
             final String newDefaultValue = dialog.getValue();
 
             if (!this.propertyBeingEdited.addDefaultValue(newDefaultValue)) {
-                MessageFormDialog.openError(getShell(), UiMessages.errorDialogTitle, JcrUiUtils.getCndEditorImage(),
+                MessageFormDialog.openError(getShell(),
+                                            UiMessages.errorDialogTitle,
+                                            JcrUiUtils.getCndEditorImage(),
                                             NLS.bind(CndMessages.errorAddingDefaultValue, newDefaultValue));
             }
         }
@@ -1168,7 +1177,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog#getSettings()
              */
             @Override
@@ -1183,7 +1192,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog.Validator#validate(java.lang.String)
                      */
                     @Override
@@ -1213,7 +1222,9 @@ final class PropertyDialog extends FormDialog {
             final String newValueConstraint = dialog.getValue();
 
             if (!this.propertyBeingEdited.addValueConstraint(newValueConstraint)) {
-                MessageFormDialog.openError(getShell(), UiMessages.errorDialogTitle, JcrUiUtils.getCndEditorImage(),
+                MessageFormDialog.openError(getShell(),
+                                            UiMessages.errorDialogTitle,
+                                            JcrUiUtils.getCndEditorImage(),
                                             NLS.bind(CndMessages.errorAddingValueConstraint, newValueConstraint));
             }
         }
@@ -1245,10 +1256,14 @@ final class PropertyDialog extends FormDialog {
         final String defaultValue = getSelectedDefaultValue();
 
         // show confirmation dialog
-        if (MessageFormDialog.openQuestion(getShell(), CndMessages.deleteDefaultValueDialogTitle, JcrUiUtils.getCndEditorImage(),
+        if (MessageFormDialog.openQuestion(getShell(),
+                                           CndMessages.deleteDefaultValueDialogTitle,
+                                           JcrUiUtils.getCndEditorImage(),
                                            NLS.bind(CndMessages.deleteDefaultValueDialogMessage, defaultValue))) {
             if (!this.propertyBeingEdited.removeDefaultValue(defaultValue)) {
-                MessageFormDialog.openError(getShell(), UiMessages.errorDialogTitle, JcrUiUtils.getCndEditorImage(),
+                MessageFormDialog.openError(getShell(),
+                                            UiMessages.errorDialogTitle,
+                                            JcrUiUtils.getCndEditorImage(),
                                             NLS.bind(CndMessages.errorDeletingDefaultValue, defaultValue));
             }
         }
@@ -1259,11 +1274,14 @@ final class PropertyDialog extends FormDialog {
         final String valueConstraint = getSelectedValueConstraint();
 
         // show confirmation dialog
-        if (MessageFormDialog.openQuestion(getShell(), CndMessages.deleteValueConstraintDialogTitle,
+        if (MessageFormDialog.openQuestion(getShell(),
+                                           CndMessages.deleteValueConstraintDialogTitle,
                                            JcrUiUtils.getCndEditorImage(),
                                            NLS.bind(CndMessages.deleteValueConstraintDialogMessage, valueConstraint))) {
             if (!this.propertyBeingEdited.removeValueConstraint(valueConstraint)) {
-                MessageFormDialog.openError(getShell(), UiMessages.errorDialogTitle, JcrUiUtils.getCndEditorImage(),
+                MessageFormDialog.openError(getShell(),
+                                            UiMessages.errorDialogTitle,
+                                            JcrUiUtils.getCndEditorImage(),
                                             NLS.bind(CndMessages.errorDeletingValueConstraint, valueConstraint));
             }
         }
@@ -1280,7 +1298,7 @@ final class PropertyDialog extends FormDialog {
         final StringValueEditorDialog dialog = new StringValueEditorDialog(getShell()) {
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog#getSettings()
              */
             @Override
@@ -1296,12 +1314,15 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog.Validator#validate(java.lang.String)
                      */
                     @Override
                     public ValidationStatus validate( final String newValue ) {
-                        final ValidationStatus status = CndValidator.isValid(newValue, propDefn.getType(), propDefn.getName());
+                        final ValidationStatus status = CndValidator.isValid(newValue,
+                                                                             propDefn.getType(),
+                                                                             propDefn.getName(),
+                                                                             accessExistingNamespacePrefixes());
 
                         if (status.isError()) {
                             return status;
@@ -1343,8 +1364,8 @@ final class PropertyDialog extends FormDialog {
                 MessageFormDialog.openError(getShell(),
                                             UiMessages.errorDialogTitle,
                                             JcrUiUtils.getCndEditorImage(),
-                                            NLS.bind(CndMessages.errorEditingDefaultValue, new Object[] { modifiedDefaultValue,
-                                                    removed, added }));
+                                            NLS.bind(CndMessages.errorEditingDefaultValue, new Object[] {modifiedDefaultValue,
+                                                removed, added}));
             }
         }
     }
@@ -1361,7 +1382,7 @@ final class PropertyDialog extends FormDialog {
 
             /**
              * {@inheritDoc}
-             * 
+             *
              * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog#getSettings()
              */
             @Override
@@ -1377,7 +1398,7 @@ final class PropertyDialog extends FormDialog {
 
                     /**
                      * {@inheritDoc}
-                     * 
+                     *
                      * @see org.jboss.tools.modeshape.jcr.ui.cnd.StringValueEditorDialog.Validator#validate(java.lang.String)
                      */
                     @Override
@@ -1422,7 +1443,7 @@ final class PropertyDialog extends FormDialog {
                                             UiMessages.errorDialogTitle,
                                             JcrUiUtils.getCndEditorImage(),
                                             NLS.bind(CndMessages.errorEditingValueConstraint, new Object[] {
-                                                    modifiedValueConstraint, removed, added }));
+                                                modifiedValueConstraint, removed, added}));
             }
         }
     }
@@ -1455,9 +1476,9 @@ final class PropertyDialog extends FormDialog {
         final String propName = e.getPropertyName();
 
         if (PropertyName.AUTOCREATED.toString().equals(propName) || PropertyName.MANDATORY.toString().equals(propName)
-                || PropertyName.MULTIPLE.toString().equals(propName) || PropertyName.NO_FULL_TEXT.toString().equals(propName)
-                || PropertyName.NO_QUERY_ORDER.toString().equals(propName) || PropertyName.PROTECTED.toString().equals(propName)
-                || PropertyName.ON_PARENT_VERSION.toString().equals(propName) || PropertyName.QUERY_OPS.toString().equals(propName)) {
+            || PropertyName.MULTIPLE.toString().equals(propName) || PropertyName.NO_FULL_TEXT.toString().equals(propName)
+            || PropertyName.NO_QUERY_ORDER.toString().equals(propName) || PropertyName.PROTECTED.toString().equals(propName)
+            || PropertyName.ON_PARENT_VERSION.toString().equals(propName) || PropertyName.QUERY_OPS.toString().equals(propName)) {
             validateAttributes();
         } else if (PropertyName.DEFAULT_VALUES.toString().equals(propName)) {
             validateDefaultValues();
@@ -1519,8 +1540,11 @@ final class PropertyDialog extends FormDialog {
         if (errorMsg.isOk()) {
             this.scrolledForm.getMessageManager().removeMessage(errorMsg.getKey(), errorMsg.getControl());
         } else {
-            this.scrolledForm.getMessageManager().addMessage(errorMsg.getKey(), errorMsg.getMessage(), null,
-                                                             errorMsg.getMessageType(), errorMsg.getControl());
+            this.scrolledForm.getMessageManager().addMessage(errorMsg.getKey(),
+                                                             errorMsg.getMessage(),
+                                                             null,
+                                                             errorMsg.getMessageType(),
+                                                             errorMsg.getControl());
         }
     }
 

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/QualifiedNameProposalProvider.java
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/QualifiedNameProposalProvider.java
@@ -7,8 +7,8 @@
  */
 package org.jboss.tools.modeshape.jcr.ui.cnd;
 
+import java.util.Collections;
 import java.util.List;
-
 import org.eclipse.jface.fieldassist.ContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposal;
 import org.eclipse.jface.fieldassist.IContentProposalProvider;
@@ -19,6 +19,21 @@ import org.jboss.tools.modeshape.jcr.Utils;
  * Provides proposals based on the qualifier part of a qualified name.
  */
 abstract class QualifiedNameProposalProvider implements IContentProposalProvider {
+
+    public static final QualifiedNameProposalProvider NO_PROPOSALS_PROVIDER = new QualifiedNameProposalProvider() {
+
+        /**
+         * {@inheritDoc}
+         * 
+         * @see org.jboss.tools.modeshape.jcr.ui.cnd.QualifiedNameProposalProvider#qnameStartsWith(java.lang.String,
+         *      java.lang.String)
+         */
+        @Override
+        protected List<QualifiedName> qnameStartsWith( final String qualifier,
+                                                       final String namePattern ) {
+            return Collections.emptyList();
+        }
+    };
 
     private String qualifier;
 

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/WorkspaceRegistry.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/WorkspaceRegistry.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.osgi.util.NLS;
 import org.jboss.tools.modeshape.jcr.cnd.CndImporter;
@@ -130,17 +129,23 @@ public class WorkspaceRegistry {
 
     /**
      * Obtains the node type definitions registered to the specified namespace.
-     * 
-     * @param namespacePrefix the namespace prefix of the node type definitions being requested (cannot be <code>null</code> or
+     *
+     * @param namespacePrefix the namespace prefix of the node type definitions being requested (can be <code>null</code> or
      *            empty)
      * @return the requested node type definitions (never <code>null</code> but can be empty)
      */
     public List<NodeTypeDefinition> getMatchingNodeTypeDefinitions( final String namespacePrefix ) {
-        Utils.verifyIsNotEmpty(namespacePrefix, "namespacePrefix"); //$NON-NLS-1$
+        final boolean matchEmptyPrefix = Utils.isEmpty(namespacePrefix);
         final List<NodeTypeDefinition> matches = new ArrayList<NodeTypeDefinition>();
 
         for (final NodeTypeDefinition nodeType : getNodeTypeDefinitions()) {
-            if (namespacePrefix.equals(nodeType.getQualifiedName().getQualifier())) {
+            final String qualifier = nodeType.getQualifiedName().getQualifier();
+
+            if (matchEmptyPrefix) {
+                if (Utils.isEmpty(qualifier)) {
+                    matches.add(nodeType);
+                }
+            } else if (namespacePrefix.equals(qualifier)) {
                 matches.add(nodeType);
             }
         }

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CndValidator.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CndValidator.java
@@ -53,11 +53,13 @@ public final class CndValidator {
      * @param value the value being checked (can be <code>null</code> or empty)
      * @param propertyType the property type of the property definition the value is for (cannot be <code>null</code>)
      * @param propertyName the name to use to identify the property definition (cannot be <code>null</code> empty)
+     * @param validNamespacePrefixes the valid namespace prefixes (can be <code>null</code> or empty)
      * @return the status (never <code>null</code>)
      */
     public static ValidationStatus isValid( final String value,
                                             final PropertyType propertyType,
-                                            String propertyName ) {
+                                            String propertyName,
+                                            final Collection<String> validNamespacePrefixes ) {
         Utils.verifyIsNotNull(propertyType, "propertyType"); //$NON-NLS-1$
 
         if (Utils.isEmpty(propertyName)) {
@@ -117,7 +119,7 @@ public final class CndValidator {
                                                                         PropertyType.LONG));
                 }
             } else if (PropertyType.NAME == propertyType) {
-                return validateQualifiedName(QualifiedName.parse(value), propertyName, null, null);
+                return validateQualifiedName(QualifiedName.parse(value), propertyName, validNamespacePrefixes, null);
             } else if (PropertyType.PATH == propertyType) {
                 return validatePath(value, propertyName);
             } else if (PropertyType.REFERENCE == propertyType) {
@@ -142,13 +144,15 @@ public final class CndValidator {
      * @param value the value being checked (can be <code>null</code> or empty)
      * @param propertyType the property type of the property definition the value is for (cannot be <code>null</code>)
      * @param propertyName the name to use to identify the property definition (cannot be <code>null</code> empty)
+     * @param validNamespacePrefixes the valid namespace prefixes (can be <code>null</code> or empty)
      * @param status the status to add the new status to (cannot be <code>null</code>)
      */
     public static void isValid( final String value,
                                 final PropertyType propertyType,
                                 final String propertyName,
+                                final Collection<String> validNamespacePrefixes,
                                 final MultiValidationStatus status ) {
-        final ValidationStatus newStatus = isValid(value, propertyType, propertyName);
+        final ValidationStatus newStatus = isValid(value, propertyType, propertyName, validNamespacePrefixes);
 
         if (!newStatus.isOk()) {
             status.add(newStatus);
@@ -512,7 +516,7 @@ public final class CndValidator {
 
             for (final String defaultValue : defaultValues) {
                 // ERROR - Default value is not valid for the property definition type
-                isValid(defaultValue, propertyType, Messages.defaultValue, status);
+                isValid(defaultValue, propertyType, Messages.defaultValue, validNamespacePrefixes, status);
 
                 // make sure if NAME type the qualifier is valid
                 final Collection<String> qualifiers = (Utils.isEmpty(validNamespacePrefixes) ? Collections.<String>emptyList() : validNamespacePrefixes);

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinition.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinition.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -91,7 +90,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If added, broadcasts a {@link PropertyChangeEvent} with an old value of <code>null</code> and a new value equal to
      * <code>namespaceMappingToAdd</code>.
-     * 
+     *
      * @param namespaceMappingToAdd the namespace mapping being added (cannot be <code>null</code>)
      * @return <code>true</code> if added
      */
@@ -113,7 +112,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If added, broadcasts a {@link PropertyChangeEvent} with an old value of <code>null</code> and a new value of
      * <code>nodeTypeDefinitionToAdd</code>.
-     * 
+     *
      * @param nodeTypeDefinitionToAdd the node type definition being added (cannot be <code>null</code>)
      * @return <code>true</code> if added
      */
@@ -135,7 +134,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If at least one namespace mapping was removed, broadcasts a {@link PropertyChangeEvent} with an old value equal to the old
      * namespace mappings collection and a new value of <code>null</code>.
-     * 
+     *
      * @return <code>true</code> if at least one namespace mapping was removed
      */
     public boolean clearNamespaceMappings() {
@@ -159,7 +158,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If at least one node type definition was removed, broadcasts a {@link PropertyChangeEvent} with an old value equal to the old
      * node type definitions collection and a new value of <code>null</code>.
-     * 
+     *
      * @return <code>true</code> if at least one namespace mapping was removed
      */
     public boolean clearNodeTypeDefinitions() {
@@ -182,7 +181,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -220,7 +219,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * The node type definition must exist in this CND for it to return child nodes.
-     * 
+     *
      * @param nodeTypeDefinitionName the name of the node type definition whose child nodes are being requested (cannot be
      *            <code>null</code> or empty)
      * @param includeInherited indicates if inherited child nodes should be included
@@ -258,7 +257,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * The node type definition must exist in this CND for it to return child nodes.
-     * 
+     *
      * @param nodeTypeDefinitionName the name of the node type definition whose item definitions are being requested (cannot be
      *            <code>null</code> or empty)
      * @param includeInherited indicates if inherited item definitions should be included
@@ -275,19 +274,25 @@ public class CompactNodeTypeDefinition implements CndElement {
     }
 
     /**
-     * @param namespacePrefix the namespace prefix of the node type definitions being requested (cannot be <code>null</code> or
+     * @param namespacePrefix the namespace prefix of the node type definitions being requested (can be <code>null</code> or
      *            empty)
      * @param includeInherited indicates if inherited node type definitions should be included
      * @return the requested node type definitions (never <code>null</code> but can be empty)
      */
     public List<NodeTypeDefinition> getMatchingNodeTypeDefinitions( final String namespacePrefix,
                                                                     final boolean includeInherited ) {
-        Utils.verifyIsNotEmpty(namespacePrefix, "namespacePrefix"); //$NON-NLS-1$
+        final boolean matchEmptyPrefix = Utils.isEmpty(namespacePrefix);
         final List<NodeTypeDefinition> matches = new ArrayList<NodeTypeDefinition>();
 
         // collect local matches
         for (final NodeTypeDefinition nodeType : getNodeTypeDefinitions()) {
-            if (namespacePrefix.equals(nodeType.getQualifiedName().getQualifier())) {
+            final String qualifier = nodeType.getQualifiedName().getQualifier();
+
+            if (matchEmptyPrefix) {
+                if (Utils.isEmpty(qualifier)) {
+                    matches.add(nodeType);
+                }
+            } else if (namespacePrefix.equals(qualifier)) {
                 matches.add(nodeType);
             }
         }
@@ -367,7 +372,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * The node type definition must exist in this CND for it to return properties.
-     * 
+     *
      * @param nodeTypeDefinitionName the name of the node type definition whose properties are being requested (cannot be
      *            <code>null</code> or empty)
      * @param includeInherited indicates if inherited properties should be included
@@ -405,7 +410,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -454,7 +459,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If namespace mapping is removed, broadcasts a {@link PropertyChangeEvent} with an old value of
      * <code>namespaceMappingToRemove</code> and a new value of <code>null</code>.
-     * 
+     *
      * @param namespaceMappingToRemove the namespace mapping being removed (cannot be <code>null</code>)
      * @return <code>true</code> if removed
      */
@@ -477,7 +482,7 @@ public class CompactNodeTypeDefinition implements CndElement {
     /**
      * If node type definition is removed, broadcasts a {@link PropertyChangeEvent} with an old value of
      * <code>nodeTypeDefinitionToRemove</code> and a new value of <code>null</code>.
-     * 
+     *
      * @param nodeTypeDefinitionToRemove the node type definition being removed (cannot be <code>null</code>)
      * @return <code>true</code> if removed
      */
@@ -499,7 +504,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.cnd.CndElement#toCndNotation(org.jboss.tools.modeshape.jcr.cnd.CndElement.NotationType)
      */
     @Override
@@ -560,7 +565,7 @@ public class CompactNodeTypeDefinition implements CndElement {
 
         /**
          * {@inheritDoc}
-         * 
+         *
          * @see java.lang.Enum#toString()
          */
         @Override

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CndValidatorTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CndValidatorTest.java
@@ -756,4 +756,61 @@ public class CndValidatorTest {
         assertTrue(status.isError());
         assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.NAME_QUALIFIER_NOT_FOUND)); //$NON-NLS-1$
     }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void isValidShouldNotAllowNullPropertyType() {
+        CndValidator.isValid("value", null, "propertyName", null);
+    }
+
+    @Test
+    public void isValidShouldNotAllowEmptyPropertyValue() {
+        final ValidationStatus status = CndValidator.isValid(null, PropertyType.STRING, "propertyName", null);
+        assertTrue(status.isError());
+        assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.EMPTY_VALUE)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void validBooleanValuesShouldBeValid() {
+        { // true
+            final ValidationStatus status = CndValidator.isValid(Boolean.TRUE.toString(),
+                                                                 PropertyType.BOOLEAN,
+                                                                 "propertyName",
+                                                                 null);
+            assertTrue(status.isOk());
+        }
+
+        { // false
+            final ValidationStatus status = CndValidator.isValid(Boolean.FALSE.toString(),
+                                                                 PropertyType.BOOLEAN,
+                                                                 "propertyName",
+                                                                 null);
+            assertTrue(status.isOk());
+        }
+    }
+
+    @Test
+    public void invalidBooleanValuesShouldNotBeValid() {
+        final ValidationStatus status = CndValidator.isValid("badValue", PropertyType.BOOLEAN, "propertyName", null);
+        assertTrue(status.isError());
+        assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.INVALID_PROPERTY_VALUE_FOR_TYPE)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void unregisteredQualifierForNamePropertyValueShouldNotBeValid() {
+        final ValidationStatus status = CndValidator.isValid("nt:name",
+                                                             PropertyType.NAME,
+                                                             "propertyName",
+                                                             Constants.Helper.getDefaultNamespacePrefixes());
+        assertTrue(status.isError());
+        assertTrue("Code is " + status.getCode(), status.containsCode(StatusCodes.NAME_QUALIFIER_NOT_FOUND)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void registeredQualifierForNamePropertyValueShouldBeValid() {
+        final ValidationStatus status = CndValidator.isValid(Constants.NAMESPACE_PREFIX1 + ":name",
+                                                             PropertyType.NAME,
+                                                             "propertyName",
+                                                             Constants.Helper.getDefaultNamespacePrefixes());
+        assertTrue(status.isOk());
+    }
 }

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinitionTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinitionTest.java
@@ -11,28 +11,82 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
+import java.util.ArrayList;
+import java.util.List;
 import org.jboss.tools.modeshape.jcr.Listener;
 import org.jboss.tools.modeshape.jcr.NamespaceMapping;
 import org.jboss.tools.modeshape.jcr.NodeTypeDefinition;
+import org.jboss.tools.modeshape.jcr.Utils;
 import org.jboss.tools.modeshape.jcr.cnd.CompactNodeTypeDefinition.PropertyName;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * 
+ *
  */
 public class CompactNodeTypeDefinitionTest {
+
+    private static List<NodeTypeDefinition> _nodeTypeDefinitions;
+
+    private static final int EMPTY_PREFIX_NODE_TYPE_MATCHES = 2;
+    private static final int NT_NODE_TYPE_MATCHES = 3;
+    private static final int JCR_NODE_TYPE_MATCHES = 4;
 
     private CompactNodeTypeDefinition cnd;
     private NamespaceMapping namespaceMapping;
     private NodeTypeDefinition nodeTypeDefinition;
+
+    private void addNodeTypeDefinitions() {
+        for (NodeTypeDefinition ntd : _nodeTypeDefinitions) {
+            this.cnd.addNodeTypeDefinition(ntd);
+        }
+    }
 
     @Before
     public void beforeEach() {
         this.cnd = new CompactNodeTypeDefinition();
         this.namespaceMapping = new NamespaceMapping();
         this.nodeTypeDefinition = new NodeTypeDefinition();
+
+        if (_nodeTypeDefinitions == null) {
+            _nodeTypeDefinitions = new ArrayList<NodeTypeDefinition>();
+
+            NodeTypeDefinition nodeType = new NodeTypeDefinition();
+            nodeType.setName("unqualified1");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("unqualified2");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("nt:nt1");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("nt:nt2");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("nt:nt3");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("jcr:jcr1");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("jcr:jcr2");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("jcr:jcr3");
+            _nodeTypeDefinitions.add(nodeType);
+
+            nodeType = new NodeTypeDefinition();
+            nodeType.setName("jcr:jcr4");
+            _nodeTypeDefinitions.add(nodeType);
+        }
     }
 
     @Test
@@ -52,12 +106,12 @@ public class CompactNodeTypeDefinitionTest {
         assertEquals(this.nodeTypeDefinition, this.cnd.getNodeTypeDefinitions().iterator().next());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test( expected = IllegalArgumentException.class )
     public void shouldNotAllowNullNamespaceToBeAdded() {
         this.cnd.addNamespaceMapping(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test( expected = IllegalArgumentException.class )
     public void shouldNotAllowNullNodeTypeDefinitionToBeAdded() {
         this.cnd.addNodeTypeDefinition(null);
     }
@@ -148,5 +202,37 @@ public class CompactNodeTypeDefinitionTest {
         assertTrue(this.cnd.addNodeTypeDefinition(this.nodeTypeDefinition));
         assertTrue(this.cnd.removeNodeTypeDefinition(this.nodeTypeDefinition));
         assertEquals(0, this.cnd.getNodeTypeDefinitions().size());
+    }
+
+    @Test
+    public void shouldMatchEmptyPrefixNodeTypeDefinitions() {
+        addNodeTypeDefinitions();
+
+        { // NT matches
+            final String prefix = "nt";
+            List<NodeTypeDefinition> matches = this.cnd.getMatchingNodeTypeDefinitions(prefix, false);
+            assertEquals(NT_NODE_TYPE_MATCHES, matches.size());
+        }
+
+        { // JCR matches
+            final String prefix = "jcr";
+            List<NodeTypeDefinition> matches = this.cnd.getMatchingNodeTypeDefinitions(prefix, false);
+            assertEquals(JCR_NODE_TYPE_MATCHES, matches.size());
+        }
+    }
+
+    @Test
+    public void shouldMatchPrefixNodeTypeDefinitions() {
+        addNodeTypeDefinitions();
+
+        { // null matches
+            List<NodeTypeDefinition> matches = this.cnd.getMatchingNodeTypeDefinitions(null, false);
+            assertEquals(EMPTY_PREFIX_NODE_TYPE_MATCHES, matches.size());
+        }
+
+        { // empty matches
+            List<NodeTypeDefinition> matches = this.cnd.getMatchingNodeTypeDefinitions(Utils.EMPTY_STRING, false);
+            assertEquals(EMPTY_PREFIX_NODE_TYPE_MATCHES, matches.size());
+        }
     }
 }


### PR DESCRIPTION
Problem was registered namespace prefixes were not being passed in to validator. Also fixed some issues with having an empty namespace prefix.
