### PR TITLE
License file, CND notation, version upgrade

### DIFF
--- a/LICENSE-EPL.txt
+++ b/LICENSE-EPL.txt
@@ -1,0 +1,70 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.

--- a/LICENSE-LGPL.txt
+++ b/LICENSE-LGPL.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,10 @@
+Red Hat, Inc. licenses these features and plugins to you under certain open source 
+licenses (or aggregations of such licenses), which in a particular case may include:
+
+- the Eclipse Public License (see LICENSE-EPL.txt)
+- the GNU Lesser General Public License (see LICENSE-LGPL.txt) 
+- and/or certain other open source licenses.
+
+For precise licensing details, consult the corresponding source code, or contact 
+Red Hat Legal Affairs, 1801 Varsity Drive, Raleigh NC 27606 USA.
+

--- a/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.feature"
       label="%featureName"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.jcr.ui"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.test.feature"
       label="%featureName"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.feature"
       label="%featureName"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.rest"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.rest.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.test.feature"
       label="%featureName"
-      version="3.1.0.qualifier"
+      version="3.2.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.client;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.client/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.client</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.doc.user;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.jcr.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.ui;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.ui</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr</artifactId>	

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/ChildNodeDefinition.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/ChildNodeDefinition.java
@@ -746,11 +746,6 @@ public class ChildNodeDefinition implements ItemDefinition, NodeDefinitionTempla
     public String toCndNotation( final NotationType notationType ) {
         final JcrPreferenceStore prefStore = JcrPreferenceStore.get();
         final StringBuilder builder = new StringBuilder();
-        String indent = Utils.EMPTY_STRING;
-
-        if (NotationType.LONG == notationType) {
-            indent = prefStore.get(JcrPreferenceConstants.CndPreference.ELEMENTS_START_DELIMITER);
-        }
 
         { // comment
             if (!Utils.isEmpty(this.comment)) {
@@ -760,14 +755,10 @@ public class ChildNodeDefinition implements ItemDefinition, NodeDefinitionTempla
                     commentNotation += '\n';
                 }
 
-                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment, indent) + '\n';
+                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment);
 
                 // add comment above node type
                 builder.append(commentNotation);
-
-                if (NotationType.LONG == notationType) {
-                    builder.append(indent);
-                }
             }
         }
 

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/NamespaceMapping.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/NamespaceMapping.java
@@ -281,7 +281,7 @@ public class NamespaceMapping implements CommentedCndElement, Comparable<Namespa
                 commentNotation += '\n';
             }
 
-            commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment, null) + '\n';
+            commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment);
 
             // add comment above namespace
             builder.append(commentNotation);

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/NodeTypeDefinition.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/NodeTypeDefinition.java
@@ -879,7 +879,7 @@ public class NodeTypeDefinition
                     commentNotation += '\n';
                 }
 
-                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment, null) + '\n';
+                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment);
 
                 // add comment above node type
                 builder.append(commentNotation);
@@ -916,14 +916,9 @@ public class NodeTypeDefinition
             final List<CndElement> elements = getElements();
 
             if (!Utils.isEmpty(elements)) {
-                final String elementStartDelimiter = prefStore.get(JcrPreferenceConstants.CndPreference.ELEMENTS_START_DELIMITER);
                 final String elementDelimiter = prefStore.get(JcrPreferenceConstants.CndPreference.ELEMENT_DELIMITER);
 
                 for (final CndElement element : elements) {
-                    if (NotationType.LONG == notationType) {
-                        builder.append(elementStartDelimiter);
-                    }
-
                     builder.append(element.toCndNotation(notationType));
                     builder.append(elementDelimiter);
                 }

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/PropertyDefinition.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/PropertyDefinition.java
@@ -12,10 +12,8 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.PropertyDefinitionTemplate;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -136,7 +134,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * Constructs an instance with a default type of {@link PropertyType#STRING}.
-     * 
+     *
      * @param ownerProvider the item owner provider that owns this property (cannot be <code>null</code>)
      */
     public PropertyDefinition( final ItemOwnerProvider ownerProvider ) {
@@ -154,7 +152,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If added, broadcasts a {@link PropertyChangeEvent} with an old value of <code>null</code> and a new value equal to
      * <code>defaultValueBeingAdded</code>.
-     * 
+     *
      * @param defaultValueBeingAdded the default value being added (cannot be <code>null</code>)
      * @return <code>true</code> if added
      */
@@ -192,7 +190,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If added, broadcasts a {@link PropertyChangeEvent} with an old value of <code>null</code> and a new value equal to
      * <code>valueConstraintBeingAdded</code>.
-     * 
+     *
      * @param valueConstraintBeingAdded the value constraint being added (cannot be <code>null</code>)
      * @return <code>true</code> if added
      */
@@ -209,7 +207,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
      * If state was changed, a property change event is broadcast to all registered listeners. Can be used to change the
      * autocreated, default values, mandatory, multiple, no full text, no query order, on parent version variant, protected, query
      * operators, property type, and value constraints properties.
-     * 
+     *
      * @param propertyName the property whose attribute state is being changed (cannot be <code>null</code>)
      * @param newState the new attribute state (cannot be <code>null</code>)
      * @return <code>true</code> if the attribute state was changed
@@ -273,7 +271,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If at least one default value was removed, broadcasts a {@link PropertyChangeEvent} with an old value equal to the old
      * default values collection and a new value of <code>null</code>.
-     * 
+     *
      * @return <code>true</code> if at least one default value was removed
      */
     public boolean clearDefaultValues() {
@@ -290,7 +288,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If at least one value constraint was removed, broadcasts a {@link PropertyChangeEvent} with an old value equal to the old
      * value constraints collection and a new value of <code>null</code>.
-     * 
+     *
      * @return <code>true</code> if at least one value constraint was removed
      */
     public boolean clearValueConstraints() {
@@ -306,7 +304,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     @Override
@@ -316,7 +314,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -374,7 +372,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#getAvailableQueryOperators()
      */
     @Override
@@ -384,7 +382,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.cnd.CommentedCndElement#getComment()
      */
     @Override
@@ -394,7 +392,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#getDeclaringNodeType()
      * @throws UnsupportedOperationException if method is called
      */
@@ -405,7 +403,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.ItemDefinition#getDeclaringNodeTypeDefinitionName()
      */
     @Override
@@ -415,7 +413,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#getDefaultValues()
      */
     @Override
@@ -432,7 +430,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#getName()
      */
     @Override
@@ -447,7 +445,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#getOnParentVersion()
      */
     @Override
@@ -457,7 +455,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.ItemDefinition#getQualifiedName()
      */
     @Override
@@ -467,7 +465,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#getRequiredType()
      */
     @Override
@@ -478,7 +476,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * Can be used to find the attribute state of the autocreated, default values, mandatory, multiple, no full text, no query
      * order, on parent version, protected, query operators, property type, and value constraints properties.
-     * 
+     *
      * @param propertyName the property whose attribute state is being requested (cannot be <code>null</code>)
      * @return the attribute state (never <code>null</code>)
      * @throws IllegalArgumentException if a property that does not have an attribute state is specified
@@ -542,7 +540,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#getValueConstraints()
      */
     @Override
@@ -560,7 +558,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -571,7 +569,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#isAutoCreated()
      */
     @Override
@@ -581,7 +579,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#isFullTextSearchable()
      */
     @Override
@@ -591,7 +589,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#isMandatory()
      */
     @Override
@@ -601,7 +599,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#isMultiple()
      */
     @Override
@@ -611,7 +609,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.ItemDefinition#isProtected()
      */
     @Override
@@ -621,7 +619,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinition#isQueryOrderable()
      */
     @Override
@@ -675,7 +673,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If default value is removed, broadcasts a {@link PropertyChangeEvent} with an old value of
      * <code>defaultValueBeingRemoved</code> and a new value of <code>null</code>.
-     * 
+     *
      * @param defaultValueBeingRemoved the default value being removed (cannot be <code>null</code>)
      * @return <code>true</code> if removed
      */
@@ -713,7 +711,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
     /**
      * If value constraint is removed, broadcasts a {@link PropertyChangeEvent} with an old value of
      * <code>valueConstraintBeingRemoved</code> and a new value of <code>null</code>.
-     * 
+     *
      * @param valueConstraintBeingRemoved the value constraint being removed (cannot be <code>null</code>)
      * @return <code>true</code> if removed
      */
@@ -728,7 +726,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setAutoCreated(boolean)
      */
     @Override
@@ -739,7 +737,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setAvailableQueryOperators(java.lang.String[])
      */
     @Override
@@ -771,7 +769,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.cnd.CommentedCndElement#setComment(java.lang.String)
      */
     @Override
@@ -793,7 +791,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setDefaultValues(javax.jcr.Value[])
      */
     @Override
@@ -824,7 +822,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setFullTextSearchable(boolean)
      */
     @Override
@@ -835,7 +833,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setMandatory(boolean)
      */
     @Override
@@ -846,7 +844,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setMultiple(boolean)
      */
     @Override
@@ -869,7 +867,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setOnParentVersion(int)
      */
     @Override
@@ -883,7 +881,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * If changed, a property change event is broadcast to all registered listeners.
-     * 
+     *
      * @param newOpv the new OPV value (cannot be <code>null</code>)
      * @return <code>true</code> if successfully changed
      */
@@ -900,7 +898,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setProtected(boolean)
      */
     @Override
@@ -911,7 +909,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setQueryOrderable(boolean)
      */
     @Override
@@ -922,7 +920,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setRequiredType(int)
      */
     @Override
@@ -932,7 +930,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * If type is changed, a {@link PropertyChangeEvent} is broadcast.
-     * 
+     *
      * @param newType the proposed new type (cannot be <code>null</code>)
      * @return <code>true</code> if the type was changed
      */
@@ -949,7 +947,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see javax.jcr.nodetype.PropertyDefinitionTemplate#setValueConstraints(java.lang.String[])
      */
     @Override
@@ -972,18 +970,13 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.jboss.tools.modeshape.jcr.cnd.CndElement#toCndNotation(org.jboss.tools.modeshape.jcr.cnd.CndElement.NotationType)
      */
     @Override
     public String toCndNotation( final NotationType notationType ) {
         final JcrPreferenceStore prefStore = JcrPreferenceStore.get();
         final StringBuilder builder = new StringBuilder();
-        String indent = Utils.EMPTY_STRING;
-
-        if (NotationType.LONG == notationType) {
-            indent = prefStore.get(JcrPreferenceConstants.CndPreference.ELEMENTS_START_DELIMITER);
-        }
 
         { // comment
             if (!Utils.isEmpty(this.comment)) {
@@ -993,14 +986,10 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
                     commentNotation += '\n';
                 }
 
-                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment, indent) + '\n';
+                commentNotation += CommentedCndElement.Helper.addCommentCharacters(this.comment);
 
                 // add comment above node type
                 builder.append(commentNotation);
-
-                if (NotationType.LONG == notationType) {
-                    builder.append(indent);
-                }
             }
         }
 
@@ -1090,7 +1079,7 @@ public class PropertyDefinition implements ItemDefinition, PropertyDefinitionTem
 
         /**
          * {@inheritDoc}
-         * 
+         *
          * @see java.lang.Enum#toString()
          */
         @Override

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CommentedCndElement.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CommentedCndElement.java
@@ -54,31 +54,25 @@ public interface CommentedCndElement extends CndElement {
 
         /**
          * @param text the text that the comment characters will be added to (cannot be <code>null</code>)
-         * @param indent an optional indent string (can be <code>null</code> or empty)
          * @return the commented text (never <code>null</code>)
          */
-        public static String addCommentCharacters( final String text,
-                                                   String indent ) {
+        public static String addCommentCharacters( final String text ) {
             Utils.verifyIsNotNull(text, "text"); //$NON-NLS-1$
 
-            if (indent == null) {
-                indent = Utils.EMPTY_STRING;
-            }
-
-            final StringBuilder builder = new StringBuilder(indent + BLOCK_COMMENT_START_CHARS);
+            final StringBuilder builder = new StringBuilder(BLOCK_COMMENT_START_CHARS);
 
             if (!text.startsWith("\n")) { //$NON-NLS-1$
                 builder.append('\n');
             }
 
-            builder.append(indent + BLOCK_COMMENT_INNER_CHARS);
-            builder.append(text.replace("\n", '\n' + indent + BLOCK_COMMENT_INNER_CHARS)); //$NON-NLS-1$
+            builder.append(BLOCK_COMMENT_INNER_CHARS);
+            builder.append(text.replace("\n", '\n' + BLOCK_COMMENT_INNER_CHARS)); //$NON-NLS-1$
 
             if (!text.endsWith("\n")) { //$NON-NLS-1$
                 builder.append('\n');
             }
 
-            builder.append(indent + Utils.SPACE_STRING).append(BLOCK_COMMENT_END_CHARS);
+            builder.append(Utils.SPACE_STRING).append(BLOCK_COMMENT_END_CHARS).append('\n');
             return builder.toString();
         }
 

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/preference/JcrPreferenceConstants.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/preference/JcrPreferenceConstants.java
@@ -65,11 +65,6 @@ public interface JcrPreferenceConstants {
         ELEMENTS_END_DELIMITER,
 
         /**
-         * The delimiter before each node type definition's item definitions (properties, child nodes).
-         */
-        ELEMENTS_START_DELIMITER,
-
-        /**
          * The delimiter between namespace mappings.
          */
         NAMESPACE_MAPPING_DELIMITER,

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/preference/JcrPreferenceStore.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/preference/JcrPreferenceStore.java
@@ -9,7 +9,6 @@ package org.jboss.tools.modeshape.jcr.preference;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
@@ -126,7 +125,7 @@ public final class JcrPreferenceStore extends AbstractPreferenceInitializer {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
      */
     @Override
@@ -137,7 +136,6 @@ public final class JcrPreferenceStore extends AbstractPreferenceInitializer {
         prefs.put(CndPreference.CHILD_NODE_PROPERTY_DELIMITER.getId(), Utils.SPACE_STRING);
         prefs.put(CndPreference.ELEMENT_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         prefs.put(CndPreference.ELEMENTS_END_DELIMITER.getId(), Utils.EMPTY_STRING);
-        prefs.put(CndPreference.ELEMENTS_START_DELIMITER.getId(), "\t"); //$NON-NLS-1$
         prefs.put(CndPreference.NAMESPACE_MAPPING_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         prefs.put(CndPreference.NAMESPACE_MAPPING_SECTION_END_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         prefs.put(CndPreference.NODE_TYPE_DEFINITION_ATTRIBUTES_DELIMITER.getId(), Utils.SPACE_STRING);
@@ -160,7 +158,6 @@ public final class JcrPreferenceStore extends AbstractPreferenceInitializer {
         this.testDefaultPrefs.put(CndPreference.CHILD_NODE_PROPERTY_DELIMITER.getId(), Utils.SPACE_STRING);
         this.testDefaultPrefs.put(CndPreference.ELEMENT_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         this.testDefaultPrefs.put(CndPreference.ELEMENTS_END_DELIMITER.getId(), Utils.EMPTY_STRING);
-        this.testDefaultPrefs.put(CndPreference.ELEMENTS_START_DELIMITER.getId(), "\t"); //$NON-NLS-1$
         this.testDefaultPrefs.put(CndPreference.NAMESPACE_MAPPING_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         this.testDefaultPrefs.put(CndPreference.NAMESPACE_MAPPING_SECTION_END_DELIMITER.getId(), "\n"); //$NON-NLS-1$
         this.testDefaultPrefs.put(CndPreference.NODE_TYPE_DEFINITION_ATTRIBUTES_DELIMITER.getId(), Utils.SPACE_STRING);

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.doc.user;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Activator: org.jboss.tools.modeshape.rest.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.modeshape.rest/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest</artifactId>

--- a/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.ui;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.ui</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>modeshape</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	<name>modeshape.all</name>	
 	<packaging>pom</packaging>
 
@@ -23,7 +23,7 @@
                 <eclipse.m2e.version>1.0.0</eclipse.m2e.version>
                 <maven.dependency.version>2.5.1</maven.dependency.version>
                 <modeshape.client.version>3.1.0.Final</modeshape.client.version>
-<!--                <modeshape.client.version>3.2.0-SNAPSHOT</modeshape.client.version> -->
+<!--                <modeshape.client.version>3.2.0.Final</modeshape.client.version> -->
         </properties>
 
 	<modules>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>modeshape.site</artifactId>
@@ -16,7 +16,7 @@
 	<properties>
 		<update.site.name>ModeShape Tools</update.site.name>
 		<update.site.description>Stable Release</update.site.description>
-		<update.site.version>3.1.0.${BUILD_ALIAS}</update.site.version>
+		<update.site.version>3.2.0.${BUILD_ALIAS}</update.site.version>
 		<target.eclipse.version>4.2 (Juno)</target.eclipse.version>
 		<siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>
 	</properties>
@@ -26,7 +26,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
+				<version>0.16.0.CR1</version>
 				<executions>
 					<execution>
 						<id>generate-facade</id>

--- a/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.test;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: %bundleVendor
 Fragment-Host: org.jboss.tools.modeshape.jcr
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test</artifactId>

--- a/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.test
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.modeshape.rest,
  org.junit4,

--- a/tests/org.jboss.tools.modeshape.rest.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
MODETOOLS-52 Place a LICENSE.txt file at the top of the Git repository
MODETOOLS-53 Upgrade Plugins, Features, Site, And Poms To Version 3.2
MODETOOLS-55 Generated CND files should not have leading spaces before property and child node definitions
MODETOOLS-56 Update Site Pom's Version Of Tycho Repository Utils Plugin
Created license file at top level of git repo (and also referenced license files). Upgraded all versions to 3.2. Now no spaces appear before property and child node definitions in long form CND notation. Also updated the version of the tycho repository utils plugin.
