### PR TITLE
MODETOOLS-61, MODETOOLS-62, MODETOOLS-63 Upgrade to 3.3, Fix Workspace Area MRU

### DIFF
--- a/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.feature"
       label="%featureName"
-      version="3.2.0.qualifier"
+      version="3.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.jcr.ui"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.test.feature"
       label="%featureName"
-      version="3.2.0.qualifier"
+      version="3.3.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.feature"
       label="%featureName"
-      version="3.2.0.qualifier"
+      version="3.3.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.rest"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.rest.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.test.feature/feature.properties
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/feature.properties
@@ -14,7 +14,7 @@ featureName = ModeShape Client Tests
 featureProvider = JBoss by Red Hat
 
 descriptionUrl=http://www.jboss.org/tools
-description = Provides a resource publishing and unpublishing capability to ModeShape repositories.
+description = Provides tests relating to the resource publishing and unpublishing operations involving ModeShape repositories.
 
 copyright = ModeShape Tools is copyright 2011-2013 Red Hat, Inc.\n\
 Some portions may be licensed to Red Hat, Inc. under one or more\n\

--- a/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.test.feature"
       label="%featureName"
-      version="3.2.0.qualifier"
+      version="3.3.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.client;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.client/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.client</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.doc.user;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.jcr.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.ui;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.ui</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr</artifactId>	

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/WorkspaceRegistry.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/WorkspaceRegistry.java
@@ -47,6 +47,8 @@ public class WorkspaceRegistry {
 
     /**
      * Don't allow construction outside of this class.
+     * 
+     * @throws Exception if there is a problem finding the CND for built-in node types
      */
     private WorkspaceRegistry() throws Exception {
         final CndImporter importer = new CndImporter();

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.doc.user;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Activator: org.jboss.tools.modeshape.rest.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.modeshape.rest/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest</artifactId>

--- a/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.ui;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.ui</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,24 +6,25 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 
-                <!-- for dev use version that is latest JBT release -->
-<!--		<version>4.30.0.Alpha1-SNAPSHOT</version> -->
+        <!-- for dev use version that is latest JBT release -->
+		<version>4.1.0.Beta1-SNAPSHOT</version>
 
-                <!-- for releases use version that is compatible with latest JBDS release -->
-                <version>4.0.1.Final-SNAPSHOT</version>
+        <!-- for releases use version that is compatible with latest JBDS release -->
+        <!-- <version>4.0.1.Final-SNAPSHOT</version> -->
 		<relativePath>../build/parent/pom.xml</relativePath>
 	</parent>
+
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>modeshape</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.3.0-SNAPSHOT</version>
 	<name>modeshape.all</name>	
 	<packaging>pom</packaging>
 
-        <properties>
-                <eclipse.m2e.version>1.0.0</eclipse.m2e.version>
-                <maven.dependency.version>2.5.1</maven.dependency.version>
-                <modeshape.client.version>3.2.0.Final</modeshape.client.version>
-        </properties>
+    <properties>
+        <eclipse.m2e.version>1.0.0</eclipse.m2e.version>
+        <maven.dependency.version>2.5.1</maven.dependency.version>
+        <modeshape.client.version>3.2.0.Final</modeshape.client.version>
+    </properties>
 
 	<modules>
 		<module>features</module>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>modeshape.site</artifactId>
@@ -15,8 +15,8 @@
 
 	<properties>
 		<update.site.name>ModeShape Tools</update.site.name>
-		<update.site.description>Stable Release</update.site.description>
-		<update.site.version>3.2.0.${BUILD_ALIAS}</update.site.version>
+		<update.site.description>Development Release</update.site.description>
+		<update.site.version>3.3.0.${BUILD_ALIAS}</update.site.version>
 		<target.eclipse.version>4.2 (Juno)</target.eclipse.version>
 		<siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>
 	</properties>

--- a/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.test;singleton:=true
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: %bundleVendor
 Fragment-Host: org.jboss.tools.modeshape.jcr
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit4
+Require-Bundle: org.junit
 Bundle-ClassPath: .

--- a/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test</artifactId>

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/LocalNameTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/LocalNameTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import org.jboss.tools.modeshape.jcr.LocalName;
 import org.jboss.tools.modeshape.jcr.Utils;
 import org.jboss.tools.modeshape.jcr.preference.JcrPreferenceConstants;
@@ -65,6 +64,7 @@ public class LocalNameTest {
         this.localName.set(VALUE);
         JcrPreferenceStore.get().set(JcrPreferenceConstants.CndPreference.QUOTE_CHAR, Utils.DOUBLE_QUOTE);
         assertEquals('"' + VALUE + '"', this.localName.toCndNotation(null));
+        resetPreference(JcrPreferenceConstants.CndPreference.QUOTE_CHAR);
     }
 
     @Test
@@ -73,6 +73,7 @@ public class LocalNameTest {
         this.localName.set(VALUE);
         JcrPreferenceStore.get().set(JcrPreferenceConstants.CndPreference.QUOTE_CHAR, Utils.SINGLE_QUOTE);
         assertEquals('\'' + VALUE + '\'', this.localName.toCndNotation(null));
+        resetPreference(JcrPreferenceConstants.CndPreference.QUOTE_CHAR);
     }
 
     @Test
@@ -81,6 +82,7 @@ public class LocalNameTest {
         JcrPreferenceStore.get().set(JcrPreferenceConstants.CndPreference.QUOTE_CHAR, Utils.EMPTY_STRING);
         this.localName.set(VALUE);
         assertEquals(VALUE, this.localName.toCndNotation(null));
+        resetPreference(JcrPreferenceConstants.CndPreference.QUOTE_CHAR);
     }
 
     @Test
@@ -100,6 +102,7 @@ public class LocalNameTest {
         this.localName.set(NEW_VALUE);
         JcrPreferenceStore.get().set(JcrPreferenceConstants.CndPreference.QUOTE_CHAR, Utils.EMPTY_STRING);
         assertEquals('\'' + NEW_VALUE + '\'', this.localName.toCndNotation(null));
+        resetPreference(JcrPreferenceConstants.CndPreference.QUOTE_CHAR);
     }
 
     @Test
@@ -120,6 +123,11 @@ public class LocalNameTest {
         final String NULL_VALUE = null;
         this.localName.set(NULL_VALUE);
         assertNull(this.localName.get());
+    }
+
+    private void resetPreference( final JcrPreferenceConstants.CndPreference pref ) {
+        final JcrPreferenceStore prefStore = JcrPreferenceStore.get();
+        prefStore.set(pref, prefStore.getDefault(pref));
     }
 
 }

--- a/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.test
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.modeshape.rest,
- org.junit4,
+ org.junit,
  org.jboss.tools.modeshape.client
 Bundle-ClassPath: .
 Bundle-Vendor: %bundleVendor

--- a/tests/org.jboss.tools.modeshape.rest.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test</artifactId>

--- a/tests/org.jboss.tools.modeshape.rest.test/src/org/jboss/tools/modeshape/rest/ServerManagerTest.java
+++ b/tests/org.jboss.tools.modeshape.rest.test/src/org/jboss/tools/modeshape/rest/ServerManagerTest.java
@@ -51,6 +51,7 @@ public final class ServerManagerTest {
     @Before
     public void beforeEach() {
         this.serverManager = new ServerManager(null, new MockRestClient());
+        System.clearProperty(ServerManager.SERVER_EXISTS_PROPERTY);
     }
 
     @Test

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.3.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
MODETOOLS-61 Custom Workspace Areas Entered Previously By User Should Be Offered As A Choice In the Publish Dialog
MODETOOLS-62 REST Test Feature Description Should Be Changed To Indicate It Is A Test Feature
MODETOOLS-63 Upgrade Plugins, Features, Site, And Poms To Version 3.3
The MRU for workspace area now works. Workspace areas used during a successful publishing operation will be available for all subsequent publishing operations performed from that Eclipse workspace. Modified the REST test feature description. Updated all version to 3.3. Also fixed some test failures relating to preferences and system properties.
