### PR TITLE
JBIDE-13863, MODETOOLS-61, MODETOOLS-62, MODETOOLS-63 Modified Site Pom

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -13,11 +13,12 @@
 	
 	<packaging>eclipse-repository</packaging>
 
+    <!-- Commented out properties are now set using build job parameters -->
 	<properties>
 		<update.site.name>ModeShape Tools</update.site.name>
-		<update.site.description>Development Release</update.site.description>
+        <!-- <update.site.description>Development Release</update.site.description> -->
 		<update.site.version>3.3.0.${BUILD_ALIAS}</update.site.version>
-		<target.eclipse.version>4.2 (Juno)</target.eclipse.version>
+        <!-- <target.eclipse.version>4.3 (Kepler)</target.eclipse.version> -->
 		<siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>
 	</properties>
 


### PR DESCRIPTION
JBIDE-13863 org.junit4 replaced w/ org.junit; please update your test plugins' manifest.mf files
MODETOOLS-61 Custom Workspace Areas Entered Previously By User Should Be Offered As A Choice In the Publish Dialog
MODETOOLS-62 REST Test Feature Description Should Be Changed To Indicate It Is A Test Feature
MODETOOLS-63 Upgrade Plugins, Features, Site, And Poms To Version 3.3
Previous commit also fixed JBIDE-13863 but forgot to mention that. This commit comments out update.site.description and target.eclipse.version pom variables as those are now build parameters.
