### PR TITLE
MODETOOLS-66 Provide A Way For Users To Mark And Unmark Publish Areas

### DIFF
--- a/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/RestClientI18n.java
+++ b/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/RestClientI18n.java
@@ -127,6 +127,7 @@ public final class RestClientI18n extends NLS {
     public static String publishPagePublishTitle;
     public static String publishPageLocationGroupTitle;
     public static String publishPageMissingRepositoryStatusMsg;
+    public static String publishPageMissingPublishAreaStatusMsg;
     public static String publishPageMissingServerStatusMsg;
     public static String publishPageMissingWorkspaceStatusMsg;
     public static String publishPageNewServerButton;

--- a/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/RestClientI18n.properties
+++ b/plugins/org.jboss.tools.modeshape.rest/src/org/jboss/tools/modeshape/rest/RestClientI18n.properties
@@ -118,13 +118,14 @@ publishJobUnpublishTaskName = Unpublishing resources [{0}]
 
 publishPagePublishTitle = Publish the selected files and folders
 publishPageLocationGroupTitle = Location
+publishPageMissingPublishAreaStatusMsg = A publish area must be selected. If there aren't any to choose from, you can create one here or in the ModeShape View.
 publishPageMissingRepositoryStatusMsg = A repository must be selected
 publishPageMissingServerStatusMsg = A server must be selected
 publishPageMissingWorkspaceStatusMsg = A workspace must be selected
 publishPageNewServerButton = New...
-publishPageNoAvailableRepositoriesStatusMsg = There are no repositories available on that server, or a \nconnection to the server cannot be made.
+publishPageNoAvailableRepositoriesStatusMsg = A repository must be selected. No repositories could be available on that server, or maybe a \nconnection to the server could not be made.
 publishPageNoAvailableServersStatusMsg = A server must be created first
-publishPageNoAvailableWorkspacesStatusMsg = There are no JCR workspaces available on that server and repository, or a \nconnection to the server cannot be made.
+publishPageNoAvailableWorkspacesStatusMsg = A workspace must be selected. No workspaces could be available in that repository, or maybe a \nconnection to the server could not be made.
 publishPageNoResourcesToPublishStatusMsg = There are no files that can be published (may be due to your ignored resources preference).
 publishPageNoResourcesToUnpublishStatusMsg = There are no files that can be unpublished (may be due to your ignored resources preference).
 publishPageOpenPreferencePageLink = ( change default in your <a>preferences</a> )


### PR DESCRIPTION
Fixes an enablement issue where the publish areas combo and add button were still enabled when a workspace was not selected.
