### PR TITLE
MODETOOLS-68 Create CND Editor Validation Error When A Supertype Of A Mixin Is Not Itself A Mixin

### DIFF
--- a/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/CndFormsEditorPage.java
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/src/org/jboss/tools/modeshape/jcr/ui/cnd/CndFormsEditorPage.java
@@ -2588,7 +2588,7 @@ public class CndFormsEditorPage extends CndEditorPage implements PropertyChangeL
             final NodeTypeDefinition nodeTypeDefinition = getSelectedNodeType();
             final QualifiedName newSupertype = dialog.getQualifiedName();
 
-            // add and select new supertype
+            // add, validate, and select new supertype
             if (nodeTypeDefinition.addSuperType(newSupertype.get())) {
                 this.superTypesViewer.setSelection(new StructuredSelection(newSupertype.get()), true);
 
@@ -3814,9 +3814,8 @@ public class CndFormsEditorPage extends CndEditorPage implements PropertyChangeL
     }
 
     void validateNodeTypes() {
-        final MultiValidationStatus status = CndValidator.validateNodeTypeDefinitions(getCnd().getNodeTypeDefinitions(),
-                                                                                      getCnd().getNamespacePrefixes(),
-                                                                                      true);
+        final MultiValidationStatus status = new MultiValidationStatus();
+        CndValidator.validateNodeTypeDefinitions(getCnd(), true, status);
         updateMessage(status, this.nodeTypeSection.getDescriptionControl());
     }
 

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/Messages.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/Messages.java
@@ -318,6 +318,11 @@ public final class Messages extends NLS {
     public static String namespaceUri;
 
     /**
+     * A message indicating a node type definition has itself as a super type. One parameter, the node type name, is required.
+     */
+    public static String nodeTypeCannotBeSuperTypeOfItself;
+
+    /**
      * A message indicating a node type definition does not have any property definitions or child node definitions. One parameter,
      * the node type definition name, is required.
      */
@@ -438,6 +443,12 @@ public final class Messages extends NLS {
      * definition name, is required.
      */
     public static String superTypesExistButMarkedAsVariant;
+
+    /**
+     * A message indicating a node type definition has a super type that is not a mixin when it is itself a mixin. These two
+     * parameters, the node type name and the super type name, are required.
+     */
+    public static String superTypeNotAMixin;
 
     /**
      * A message indicating that a property value couldn't be converted from one data type to another. Three parameters, the

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinition.java
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/cnd/CompactNodeTypeDefinition.java
@@ -246,7 +246,7 @@ public class CompactNodeTypeDefinition implements CndElement {
                 if (superTypeNodeType == null) {
                     // super type not found in CND so see if it is a built-in
                     childNodes.addAll(WorkspaceRegistry.get().getChildNodeDefinitions(superType.get(), true));
-                } else {
+                } else if (!nodeTypeDefinitionName.equals(superTypeNodeType.getName())) {
                     childNodes.addAll(getChildNodeDefinitions(superTypeNodeType.getName(), true));
                 }
             }
@@ -399,7 +399,7 @@ public class CompactNodeTypeDefinition implements CndElement {
                 if (superTypeNodeType == null) {
                     // super type not found in CND so see if it is a built-in
                     properties.addAll(WorkspaceRegistry.get().getPropertyDefinitions(superType.get(), true));
-                } else {
+                } else if (!nodeTypeDefinitionName.equals(superTypeNodeType.getName())) {
                     properties.addAll(getPropertyDefinitions(superTypeNodeType.getName(), true));
                 }
             }

--- a/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/messages.properties
+++ b/plugins/org.jboss.tools.modeshape.jcr/src/org/jboss/tools/modeshape/jcr/messages.properties
@@ -38,8 +38,8 @@ duplicateQualifiedName = There are duplicate {0}s of "{1}."
 duplicateQueryOperator = There are multiple query operators of "{1}" in property definition "{0}."
 # 0 = child node definition name, 1 = duplicate required type name
 duplicateRequiredType = There are multiple required types with a name of "{1}" in child node definition "{0}."
-# 0 = node type definition name, 1 = duplicate super type name
-duplicateSuperType = There are multiple super types with a name of "{1}" in node type definition "{0}."
+# 0 = node type definition name, 1 = duplicate supertype name
+duplicateSuperType = There are multiple supertypes with a name of "{1}" in node type definition "{0}."
 # 0 = property definition name, 1 = duplicate value constraint
 duplicateValueConstraint = There are multiple value constraints of "{1}" in property definition "{0}."
 # 0 = property definition name
@@ -52,7 +52,7 @@ emptyQueryOperators = The property definition "{0}" must have at least one query
 # 0 = child node definition name
 emptyRequiredTypes = The child node definition "{0}" must have at least one required type.
 # 0 = node type definition name
-emptySuperTypes = The node type definition "{0}" must have at least one super type.
+emptySuperTypes = The node type definition "{0}" must have at least one supertype.
 # 0 = name or type of qualified name
 emptyUnqualifiedName = The {0} has an empty unqualified name.
 # 0 = property or attribute name of a node type definition, property definition, or child node definition
@@ -108,6 +108,8 @@ nameQualifierNotFound = The {0} has a qualifier of "{1}" that does not match any
 namespacePrefix = namespace prefix
 namespaceUri = namespace URI
 # 0 = node type definition name
+nodeTypeCannotBeSuperTypeOfItself = The node type definition "{0}" cannot have itself as a supertype.
+# 0 = node type definition name
 nodeTypeDefinitionHasNoPropertyDefinitionsOrChildNodeDefinitions = The node type definition "{0}" has no property definitions or child node definitions.
 nodeTypeDefinitionName = node type definition name
 # 0 = line number, 1 = column number
@@ -139,9 +141,11 @@ startMethodMustBeCalledBeforeConsumingOrMatching = The "start()" method must be 
 startMethodMustBeCalledBeforeNext = The "start()" method must be called before "hasNext()"
 # 0 = name of string
 stringIsEmpty = String {0} is empty
-superTypeName = super type name
+superTypeName = supertype name
 # 0 = node type definition name
-superTypesExistButMarkedAsVariant = Node type definition "{0}" has super types marked as a variant but has one or more super types.
+superTypesExistButMarkedAsVariant = Node type definition "{0}" has supertypes marked as a variant but has one or more supertypes.
+# 0 = mixin name, 1 = supertype name
+superTypeNotAMixin = The mixin "{0}" has the non-mixin "{1}" defined as a supertype. The supertypes of a mixin must only be other mixin node types.
 # 0 = value, 1 = from data type, 2 = to data type
 unableToConvertValue = Unable to convert '{0}' from type {1} to {2}
 # 0 = expected token, 1 = actual token, 2 = line number, 3 = column number, 4 = fragment

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 		<artifactId>parent</artifactId>
 
         <!-- Eclipse Kepler -->
-		<version>4.1.0.Beta2-SNAPSHOT</version>
+		<version>4.1.0.Final-SNAPSHOT</version>
 
         <!-- Eclipse Juno -->
         <!-- <version>4.0.1.Final-SNAPSHOT</version> -->

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/attributes/OnParentValueTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/attributes/OnParentValueTest.java
@@ -9,7 +9,6 @@ package org.jboss.tools.modeshape.jcr.cnd.attributes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import org.jboss.tools.modeshape.jcr.Utils;
 import org.jboss.tools.modeshape.jcr.attributes.OnParentVersion;
 import org.jboss.tools.modeshape.jcr.cnd.CndElement;
@@ -85,6 +84,16 @@ public class OnParentValueTest implements Constants {
         assertEquals(VERSION_NOTATION, this.attribute.toCndNotation(CndElement.NotationType.LONG));
         assertEquals(VERSION_NOTATION, this.attribute.toCndNotation(CndElement.NotationType.COMPRESSED));
         assertEquals(VERSION_NOTATION, this.attribute.toCndNotation(CndElement.NotationType.COMPACT));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidFindParameter() {
+        OnParentVersion.find("bogus");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidFindUsingJcrValueParameter() {
+        OnParentVersion.findUsingJcrValue(1234);
     }
 
 }

--- a/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/attributes/QueryOperatorsTest.java
+++ b/tests/org.jboss.tools.modeshape.jcr.test/src/org/jboss/tools/modeshape/jcr/cnd/attributes/QueryOperatorsTest.java
@@ -134,4 +134,15 @@ public class QueryOperatorsTest implements Constants {
         assertEquals(QUERY_OPS_VARIANT_COMPRESSED_FORM, this.attribute.toCndNotation(CndElement.NotationType.COMPRESSED));
         assertEquals(QUERY_OPS_VARIANT_LONG_FORM, this.attribute.toCndNotation(CndElement.NotationType.LONG));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidFindParameter() {
+        QueryOperators.QueryOperator.find("bogus");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyInvalidFindUsingJcrValueParameter() {
+        QueryOperators.QueryOperator.findUsingJcrValue("bogus");
+    }
+
 }


### PR DESCRIPTION
In the CND Editor, 2 new validation errors were added: (1) node type definition cannot be a supertype of itself, and
(2) a supertype of a mixin must also be a mixin. Also updated pom to JBoss Eclipse Kepler final target platform.
