### PR TITLE
MODETOOLS-69 Upgrade Plugins, Features, Site, And Poms To Version 3.4

### DIFF
--- a/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.feature"
       label="%featureName"
-      version="3.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.jcr.ui"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.jcr.test.feature"
       label="%featureName"
-      version="3.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.jcr.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.feature"
       label="%featureName"
-      version="3.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%featureProvider"
       plugin="org.jboss.tools.modeshape.rest"
       image="feature.png">

--- a/features/org.jboss.tools.modeshape.rest.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.feature</artifactId>

--- a/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.modeshape.rest.test.feature"
       label="%featureName"
-      version="3.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%featureProvider">
 
    <description url="%descriptionUrl">

--- a/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
+++ b/features/org.jboss.tools.modeshape.rest.test.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>features</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.features</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.client/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.client;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.client/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.3.0-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.client</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.doc.user;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.doc.user/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.tools.modeshape</groupId>
         <artifactId>plugins</artifactId>
-        <version>3.3.0-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <groupId>org.jboss.tools.modeshape.plugins</groupId>
     <artifactId>org.jboss.tools.modeshape.jcr.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.ui;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.ui</artifactId>

--- a/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.jcr/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.jcr/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.jcr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr</artifactId>	

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.doc.user;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest.doc.user/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.doc.user</artifactId>

--- a/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.rest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Activator: org.jboss.tools.modeshape.rest.Activator
 Bundle-Vendor: %bundleVendor
 Bundle-Localization: plugin

--- a/plugins/org.jboss.tools.modeshape.rest/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.rest/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest</artifactId>

--- a/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.modeshape.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.ui;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.modeshape.ui/pom.xml
+++ b/plugins/org.jboss.tools.modeshape.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>plugins</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.plugins</groupId>
 	<artifactId>org.jboss.tools.modeshape.ui</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>modeshape</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.4.0-SNAPSHOT</version>
 	<name>modeshape.all</name>	
 	<packaging>pom</packaging>
 

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>modeshape.site</artifactId>
@@ -15,8 +15,8 @@
 
 	<properties>
 		<update.site.name>ModeShape Tools</update.site.name>
-		<update.site.description>Stable Release</update.site.description>
-		<update.site.version>3.3.0.${BUILD_ALIAS}</update.site.version>
+		<update.site.description>Development Release</update.site.description>
+		<update.site.version>3.4.0.${BUILD_ALIAS}</update.site.version>
 <!--        <target.eclipse.version>4.2 (Juno)</target.eclipse.version> -->
         <target.eclipse.version>4.3 (Kepler)</target.eclipse.version>
 		<siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>

--- a/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.jcr.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.jcr.test;singleton:=true
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-Vendor: %bundleVendor
 Fragment-Host: org.jboss.tools.modeshape.jcr
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.jcr.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.jcr.test</artifactId>

--- a/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.modeshape.rest.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.modeshape.rest.test
-Bundle-Version: 3.3.0.qualifier
+Bundle-Version: 3.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.jboss.tools.modeshape.rest,
  org.junit,

--- a/tests/org.jboss.tools.modeshape.rest.test/pom.xml
+++ b/tests/org.jboss.tools.modeshape.rest.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.modeshape</groupId>
 		<artifactId>tests</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape.tests</groupId>
 	<artifactId>org.jboss.tools.modeshape.rest.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>modeshape</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.modeshape</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Updated all plugins, features, and poms to 3.4.0. Just need to update ModeShape client to 3.4.0.Final when it is released.
